### PR TITLE
use the method toSymbol instead of using the attributes ns and sym

### DIFF
--- a/src/hyperfiddle/rcf/analyzer.clj
+++ b/src/hyperfiddle/rcf/analyzer.clj
@@ -88,7 +88,7 @@
 
 (defn var-sym [v] 
   (cond
-    (var? v) (symbol (name (.name (.ns v))) (name (.sym v)))
+    (var? v) (.toSymbol v)
     (var?' v) (symbol (str (:ns v)) (str (:name v)))))
 
 (defmulti macroexpand-hook (fn [the-var _&form _&env _args] (var-sym the-var)))


### PR DESCRIPTION
The attribute ns only exists for clojure.lang.Var but not for sci.lang.Var.
The method toSymbol can be used to create a symbol from a var and exists on clojure jvm and sci.