### PR TITLE
Remove clj-kondo warning that := is an unused value

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths   ["src"]
+{:paths   ["src" "resources"]
  :deps    {org.clojure/clojure {:mvn/version "1.10.3"}}
  :aliases {:cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.10.896"}}}
            :dev  {:extra-deps {thheller/shadow-cljs {:mvn/version "2.16.8"}}}

--- a/resources/clj-kondo.exports/com.hyperfiddle/rcf/config.edn
+++ b/resources/clj-kondo.exports/com.hyperfiddle/rcf/config.edn
@@ -1,0 +1,2 @@
+{;; Removes the warning that `:=` is an unused value in `tests`
+ :config-in-call {hyperfiddle.rcf/tests {:ignore [:unused-value]}}}


### PR DESCRIPTION
`clj-kondo` does not understand that `:=` is special in `rcf/tests`. This commit adds a `clj-kondo.exports` folder as explained in their documentation. Users can use this to import the config in their projects and remove the warning.

References:
1. Exporting and importing clj-kondo configuration: https://github.com/clj-kondo/clj-kondo/blob/74be7d29696c08e188d10c64b045403b21302a0b/doc/config.md?plain=1#L524
2. An explanation of the `:config-in-call` option: https://github.com/clj-kondo/clj-kondo/blob/74be7d29696c08e188d10c64b045403b21302a0b/doc/config.md#config-in-call
3. An explanation of the `:unused-value` warning that we see: https://github.com/clj-kondo/clj-kondo/blob/74be7d29696c08e188d10c64b045403b21302a0b/doc/linters.md#unused-value